### PR TITLE
Update inventory.py

### DIFF
--- a/tools/launch-configuration-inventory/inventory.py
+++ b/tools/launch-configuration-inventory/inventory.py
@@ -90,7 +90,8 @@ def get_credentials_for_profile(profile_name):
         session_credentials = session.get_credentials() 
         credentials = {
             'aws_access_key_id'     : session_credentials.access_key,
-            'aws_secret_access_key' : session_credentials.secret_key
+            'aws_secret_access_key' : session_credentials.secret_key,
+            'aws_session_token'     : session_credentials.token
         }
         return credentials
 


### PR DESCRIPTION
Without session token, it fails to run if our current profile is already result of an STS login. (In my case it's `saml2aws` Okta login.)

*Issue #, if available:*

*Description of changes:*

Returns session token as part of credentials

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
