### PR TITLE
Set session token for AWS SSO profiles

### DIFF
--- a/tools/launch-configuration-inventory/inventory.py
+++ b/tools/launch-configuration-inventory/inventory.py
@@ -92,6 +92,10 @@ def get_credentials_for_profile(profile_name):
             'aws_access_key_id'     : session_credentials.access_key,
             'aws_secret_access_key' : session_credentials.secret_key
         }
+        
+        if hasattr(session_credentials, 'token'):
+            credentials['aws_session_token'] = session_credentials.token
+        
         return credentials
 
     except Exception as e:


### PR DESCRIPTION
For AWS SSO profile (IAM Identity Center enabled profile), it requires Session Token. This PR takes care of setting `aws_session_token` in case it is present in session credentials.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.